### PR TITLE
Bug fix for 3D textures and OBJ files

### DIFF
--- a/include/application-d3d11/D3D11Texture3D.cpp
+++ b/include/application-d3d11/D3D11Texture3D.cpp
@@ -43,7 +43,7 @@ namespace ml
 		D3D_VALIDATE(device.CreateTexture3D(&desc, nullptr, &m_texture));
 		D3D_VALIDATE(device.CreateShaderResourceView(m_texture, nullptr, &m_srv));
 
-		context.UpdateSubresource(m_texture, 0, nullptr, m_data.getData(), (UINT)m_data.getDimX() * sizeof(RGBColor), (UINT)m_data.getDimX() * (UINT)m_data.getDimY() * sizeof(RGBColor));
+		context.UpdateSubresource(m_texture, 0, nullptr, m_data.getData(), (UINT)m_data.getDimX() * sizeof(T), (UINT)m_data.getDimX() * (UINT)m_data.getDimY() * sizeof(T));
 
 		context.GenerateMips(m_srv);
 	}

--- a/include/application-d3d11/D3D11Texture3D.h
+++ b/include/application-d3d11/D3D11Texture3D.h
@@ -65,13 +65,13 @@ public:
 	void unbind(unsigned int slot = 0) const;
 
 
-    const Grid3<RGBColor>& getData() const {
+    const Grid3<T>& getData() const {
         return m_data;
     }
 
 private:
 	D3D11GraphicsDevice* m_graphics;
-    Grid3<RGBColor> m_data;
+    Grid3<T> m_data;
     ID3D11Texture3D* m_texture;
     ID3D11ShaderResourceView* m_srv;
 };

--- a/include/application-d3d11/D3D11Texture3D.h
+++ b/include/application-d3d11/D3D11Texture3D.h
@@ -24,7 +24,7 @@ public:
 	D3D11Texture3D(const D3D11Texture3D& t) {
 		m_texture = nullptr;
 		m_srv = nullptr;
-		init(g, t.getData());
+		init(*t.m_graphics, t.getData());
 	}
 	//! move constructor
     D3D11Texture3D(D3D11Texture3D&& t) {

--- a/include/core-mesh/meshIO.cpp
+++ b/include/core-mesh/meshIO.cpp
@@ -358,21 +358,21 @@ void MeshIO<FloatType>::loadFromOBJ(const std::string& filename, MeshData<FloatT
 						//This face has vertex and normal indices
 
 						//remap them to the right spot
-						idx[0][0] = (idx[0][0] > 0) ? (idx[0][0] - 1) : ((int)mesh.m_Vertices.size() - idx[0][0]);
-						idx[0][1] = (idx[0][1] > 0) ? (idx[0][1] - 1) : ((int)mesh.m_Normals.size() - idx[0][1]);
+						idx[0][0] = (idx[0][0] > 0) ? (idx[0][0] - 1) : ((int)mesh.m_Vertices.size() + idx[0][0]);
+						idx[0][1] = (idx[0][1] > 0) ? (idx[0][1] - 1) : ((int)mesh.m_Normals.size() + idx[0][1]);
 
 						//grab the second vertex to prime
 						fscanf( fp, "%d//%d", &idx[1][0], &idx[1][1]);
 
 						//remap them to the right spot
-						idx[1][0] = (idx[1][0] > 0) ? (idx[1][0] - 1) : ((int)mesh.m_Vertices.size() - idx[1][0]);
-						idx[1][1] = (idx[1][1] > 0) ? (idx[1][1] - 1) : ((int)mesh.m_Normals.size() - idx[1][1]);
+						idx[1][0] = (idx[1][0] > 0) ? (idx[1][0] - 1) : ((int)mesh.m_Vertices.size() + idx[1][0]);
+						idx[1][1] = (idx[1][1] > 0) ? (idx[1][1] - 1) : ((int)mesh.m_Normals.size() + idx[1][1]);
 
 						//create the fan
 						while ( fscanf( fp, "%d//%d", &idx[n][0], &idx[n][1]) == 2) {
 							//remap them to the right spot
-							idx[n][0] = (idx[n][0] > 0) ? (idx[n][0] - 1) : ((int)mesh.m_Vertices.size() - idx[n][0]);
-							idx[n][1] = (idx[n][1] > 0) ? (idx[n][1] - 1) : ((int)mesh.m_Normals.size() - idx[n][1]);
+							idx[n][0] = (idx[n][0] > 0) ? (idx[n][0] - 1) : ((int)mesh.m_Vertices.size() + idx[n][0]);
+							idx[n][1] = (idx[n][1] > 0) ? (idx[n][1] - 1) : ((int)mesh.m_Normals.size() + idx[n][1]);
 							n++;
 						}
 					}
@@ -381,24 +381,24 @@ void MeshIO<FloatType>::loadFromOBJ(const std::string& filename, MeshData<FloatT
 						//This face has vertex, texture coordinate, and normal indices
 
 						//remap them to the right spot
-						idx[0][0] = (idx[0][0] > 0) ? (idx[0][0] - 1) : ((int)mesh.m_Vertices.size() - idx[0][0]);
-						idx[0][1] = (idx[0][1] > 0) ? (idx[0][1] - 1) : ((int)mesh.m_TextureCoords.size() - idx[0][1]);
-						idx[0][2] = (idx[0][2] > 0) ? (idx[0][2] - 1) : ((int)mesh.m_Normals.size() - idx[0][2]);
+						idx[0][0] = (idx[0][0] > 0) ? (idx[0][0] - 1) : ((int)mesh.m_Vertices.size() + idx[0][0]);
+						idx[0][1] = (idx[0][1] > 0) ? (idx[0][1] - 1) : ((int)mesh.m_TextureCoords.size() + idx[0][1]);
+						idx[0][2] = (idx[0][2] > 0) ? (idx[0][2] - 1) : ((int)mesh.m_Normals.size() + idx[0][2]);
 
 						//grab the second vertex to prime
 						fscanf( fp, "%d/%d/%d", &idx[1][0], &idx[1][1], &idx[1][2]);
 
 						//remap them to the right spot
-						idx[1][0] = (idx[1][0] > 0) ? (idx[1][0] - 1) : ((int)mesh.m_Vertices.size() - idx[1][0]);
-						idx[1][1] = (idx[1][1] > 0) ? (idx[1][1] - 1) : ((int)mesh.m_TextureCoords.size() - idx[1][1]);
-						idx[1][2] = (idx[1][2] > 0) ? (idx[1][2] - 1) : ((int)mesh.m_Normals.size() - idx[1][2]);
+						idx[1][0] = (idx[1][0] > 0) ? (idx[1][0] - 1) : ((int)mesh.m_Vertices.size() + idx[1][0]);
+						idx[1][1] = (idx[1][1] > 0) ? (idx[1][1] - 1) : ((int)mesh.m_TextureCoords.size() + idx[1][1]);
+						idx[1][2] = (idx[1][2] > 0) ? (idx[1][2] - 1) : ((int)mesh.m_Normals.size() + idx[1][2]);
 
 						//create the fan
 						while ( fscanf( fp, "%d/%d/%d", &idx[n][0], &idx[n][1], &idx[n][2]) == 3) {
 							//remap them to the right spot
-							idx[n][0] = (idx[n][0] > 0) ? (idx[n][0] - 1) : ((int)mesh.m_Vertices.size() - idx[n][0]);
-							idx[n][1] = (idx[n][1] > 0) ? (idx[n][1] - 1) : ((int)mesh.m_TextureCoords.size() - idx[n][1]);
-							idx[n][2] = (idx[n][2] > 0) ? (idx[n][2] - 1) : ((int)mesh.m_Normals.size() - idx[n][2]);
+							idx[n][0] = (idx[n][0] > 0) ? (idx[n][0] - 1) : ((int)mesh.m_Vertices.size() + idx[n][0]);
+							idx[n][1] = (idx[n][1] > 0) ? (idx[n][1] - 1) : ((int)mesh.m_TextureCoords.size() + idx[n][1]);
+							idx[n][2] = (idx[n][2] > 0) ? (idx[n][2] - 1) : ((int)mesh.m_Normals.size() + idx[n][2]);
 							n++;
 						}
 					}
@@ -407,21 +407,21 @@ void MeshIO<FloatType>::loadFromOBJ(const std::string& filename, MeshData<FloatT
 						//This face has vertex and texture coordinate indices
 
 						//remap them to the right spot
-						idx[0][0] = (idx[0][0] > 0) ? (idx[0][0] - 1) : ((int)mesh.m_Vertices.size() - idx[0][0]);
-						idx[0][1] = (idx[0][1] > 0) ? (idx[0][1] - 1) : ((int)mesh.m_TextureCoords.size() - idx[0][1]);
+						idx[0][0] = (idx[0][0] > 0) ? (idx[0][0] - 1) : ((int)mesh.m_Vertices.size() + idx[0][0]);
+						idx[0][1] = (idx[0][1] > 0) ? (idx[0][1] - 1) : ((int)mesh.m_TextureCoords.size() + idx[0][1]);
 
 						//grab the second vertex to prime
 						fscanf( fp, "%d/%d/", &idx[1][0], &idx[1][1]);
 
 						//remap them to the right spot
-						idx[1][0] = (idx[1][0] > 0) ? (idx[1][0] - 1) : ((int)mesh.m_Vertices.size() - idx[1][0]);
-						idx[1][1] = (idx[1][1] > 0) ? (idx[1][1] - 1) : ((int)mesh.m_TextureCoords.size() - idx[1][1]);
+						idx[1][0] = (idx[1][0] > 0) ? (idx[1][0] - 1) : ((int)mesh.m_Vertices.size() + idx[1][0]);
+						idx[1][1] = (idx[1][1] > 0) ? (idx[1][1] - 1) : ((int)mesh.m_TextureCoords.size() + idx[1][1]);
 
 						//create the fan
 						while ( fscanf( fp, "%d/%d/", &idx[n][0], &idx[n][1]) == 2) {
 							//remap them to the right spot
-							idx[n][0] = (idx[n][0] > 0) ? (idx[n][0] - 1) : ((int)mesh.m_Vertices.size() - idx[n][0]);
-							idx[n][1] = (idx[n][1] > 0) ? (idx[n][1] - 1) : ((int)mesh.m_TextureCoords.size() - idx[n][1]);
+							idx[n][0] = (idx[n][0] > 0) ? (idx[n][0] - 1) : ((int)mesh.m_Vertices.size() + idx[n][0]);
+							idx[n][1] = (idx[n][1] > 0) ? (idx[n][1] - 1) : ((int)mesh.m_TextureCoords.size() + idx[n][1]);
 							n++;
 						}
 					}
@@ -430,21 +430,21 @@ void MeshIO<FloatType>::loadFromOBJ(const std::string& filename, MeshData<FloatT
 						//This face has vertex and texture coordinate indices
 
 						//remap them to the right spot
-						idx[0][0] = (idx[0][0] > 0) ? (idx[0][0] - 1) : ((int)mesh.m_Vertices.size() - idx[0][0]);
-						idx[0][1] = (idx[0][1] > 0) ? (idx[0][1] - 1) : ((int)mesh.m_TextureCoords.size() - idx[0][1]);
+						idx[0][0] = (idx[0][0] > 0) ? (idx[0][0] - 1) : ((int)mesh.m_Vertices.size() + idx[0][0]);
+						idx[0][1] = (idx[0][1] > 0) ? (idx[0][1] - 1) : ((int)mesh.m_TextureCoords.size() + idx[0][1]);
 
 						//grab the second vertex to prime
 						fscanf( fp, "%d/%d", &idx[1][0], &idx[1][1]);
 
 						//remap them to the right spot
-						idx[1][0] = (idx[1][0] > 0) ? (idx[1][0] - 1) : ((int)mesh.m_Vertices.size() - idx[1][0]);
-						idx[1][1] = (idx[1][1] > 0) ? (idx[1][1] - 1) : ((int)mesh.m_TextureCoords.size() - idx[1][1]);
+						idx[1][0] = (idx[1][0] > 0) ? (idx[1][0] - 1) : ((int)mesh.m_Vertices.size() + idx[1][0]);
+						idx[1][1] = (idx[1][1] > 0) ? (idx[1][1] - 1) : ((int)mesh.m_TextureCoords.size() + idx[1][1]);
 
 						//create the fan
 						while ( fscanf( fp, "%d/%d", &idx[n][0], &idx[n][1]) == 2) {
 							//remap them to the right spot
-							idx[n][0] = (idx[n][0] > 0) ? (idx[n][0] - 1) : ((int)mesh.m_Vertices.size() - idx[n][0]);
-							idx[n][1] = (idx[n][1] > 0) ? (idx[n][1] - 1) : ((int)mesh.m_TextureCoords.size() - idx[n][1]);
+							idx[n][0] = (idx[n][0] > 0) ? (idx[n][0] - 1) : ((int)mesh.m_Vertices.size() + idx[n][0]);
+							idx[n][1] = (idx[n][1] > 0) ? (idx[n][1] - 1) : ((int)mesh.m_TextureCoords.size() + idx[n][1]);
 							n++;
 						}
 					}
@@ -453,18 +453,18 @@ void MeshIO<FloatType>::loadFromOBJ(const std::string& filename, MeshData<FloatT
 						//This face has only vertex indices
 
 						//remap them to the right spot
-						idx[0][0] = (idx[0][0] > 0) ? (idx[0][0] - 1) : ((int)mesh.m_Vertices.size() - idx[0][0]);
+						idx[0][0] = (idx[0][0] > 0) ? (idx[0][0] - 1) : ((int)mesh.m_Vertices.size() + idx[0][0]);
 
 						//grab the second vertex to prime
 						fscanf( fp, "%d", &idx[1][0]);
 
 						//remap them to the right spot
-						idx[1][0] = (idx[1][0] > 0) ? (idx[1][0] - 1) : ((int)mesh.m_Vertices.size() - idx[1][0]);
+						idx[1][0] = (idx[1][0] > 0) ? (idx[1][0] - 1) : ((int)mesh.m_Vertices.size() + idx[1][0]);
 
 						//create the fan
 						while ( fscanf( fp, "%d", &idx[n][0]) == 1) {
 							//remap them to the right spot
-							idx[n][0] = (idx[n][0] > 0) ? (idx[n][0] - 1) : ((int)mesh.m_Vertices.size() - idx[n][0]);
+							idx[n][0] = (idx[n][0] > 0) ? (idx[n][0] - 1) : ((int)mesh.m_Vertices.size() + idx[n][0]);
 							n++;
 						}
 					}


### PR DESCRIPTION
- The template argument in the class D3D11Texture3D was incorrect (RGBColor instead of T)
- The method loadFromOBJ didn't work correctly if the OBJ file used relative indices. This has been fixed now.