### PR TITLE
Fix several compile and warning issues

### DIFF
--- a/include/core-base/baseImage.h
+++ b/include/core-base/baseImage.h
@@ -134,6 +134,7 @@ namespace ml {
                 return i.image != image;
             }
 
+            template <class T_>
             friend void swap(iterator &a, iterator &b);
 
             unsigned int x, y;
@@ -188,6 +189,7 @@ namespace ml {
                 return i.image != image;
             }
 
+            template <class T_>
             friend void swap(constIterator &a, constIterator &b);
 
             unsigned int x, y;

--- a/include/core-base/distanceField3.h
+++ b/include/core-base/distanceField3.h
@@ -186,9 +186,9 @@ namespace ml {
 		void setTruncation(float truncation, bool updateValues = true) {
 			m_truncation = truncation;
 			if (updateValues) {
-				for (unsigned int z = 0; z < m_dimZ; z++) {
-					for (unsigned int y = 0; y < m_dimY; y++) {
-						for (unsigned int x = 0; x < m_dimX; x++) {
+				for (unsigned int z = 0; z < this->m_dimZ; z++) {
+					for (unsigned int y = 0; y < this->m_dimY; y++) {
+						for (unsigned int x = 0; x < this->m_dimX; x++) {
 							float v = (*this)(x, y, z);
 							if (v > truncation) (*this)(x, y, z) = truncation;
 						} //x

--- a/include/core-base/grid3.cpp
+++ b/include/core-base/grid3.cpp
@@ -160,7 +160,7 @@ namespace ml
 						minValue = curValue;
 					}
 				}
-			return minIndex;
+		return minIndex;
 	}
 
 	template <class T> const T& Grid3<T>::getMinValue() const

--- a/include/core-math/denseMatrix.cpp
+++ b/include/core-math/denseMatrix.cpp
@@ -186,55 +186,55 @@ void DenseMatrix<FloatType>::invertInPlace()
 			(*this)(j, i) = sum / (*this)(j, j);
 		}
 
-		//
-		// invert U
-		//
-		for (UINT i = 0; i < m_rows; i++)
-			for (UINT j = i; j < m_rows; j++)
+	//
+	// invert U
+	//
+	for (UINT i = 0; i < m_rows; i++)
+		for (UINT j = i; j < m_rows; j++)
+		{
+			if ( i == j )
 			{
-				if ( i == j )
-				{
-					continue;
-				}
-				FloatType sum = 0;
-				for (UINT k = i; k < j; k++)
-				{
-					FloatType val = (FloatType)1.0;
-					if(i != k)
-					{
-						val = (*this)(i, k);
-					}
-					sum += (*this)(k, j) * val;
-				}
-				(*this)(i, j) = -sum;
+				continue;
 			}
+			FloatType sum = 0;
+			for (UINT k = i; k < j; k++)
+			{
+				FloatType val = (FloatType)1.0;
+				if(i != k)
+				{
+					val = (*this)(i, k);
+				}
+				sum += (*this)(k, j) * val;
+			}
+			(*this)(i, j) = -sum;
+		}
 
-			//
-			// final inversion
-			//
-			for (UINT i = 0; i < m_rows; i++)
+	//
+	// final inversion
+	//
+	for (UINT i = 0; i < m_rows; i++)
+	{
+		for (UINT j = 0; j < m_rows; j++)
+		{
+			FloatType sum = 0;
+			UINT larger = j;
+			if(i > j)
 			{
-				for (UINT j = 0; j < m_rows; j++)
-				{
-					FloatType sum = 0;
-					UINT larger = j;
-					if(i > j)
-					{
-						larger = i;
-					}
-					for (UINT k = larger; k < m_rows; k++)
-					{
-						FloatType val = (FloatType)1.0;
-						if(j != k)
-						{
-							val = (*this)(j, k);
-						}
-						sum += val * (*this)(k, i);
-					}
-					(*this)(j, i) = sum;
-				}
+				larger = i;
 			}
-			//Assert(ElementsValid(), "Degenerate Matrix inversion.");
+			for (UINT k = larger; k < m_rows; k++)
+			{
+				FloatType val = (FloatType)1.0;
+				if(j != k)
+				{
+					val = (*this)(j, k);
+				}
+				sum += val * (*this)(k, i);
+			}
+			(*this)(j, i) = sum;
+		}
+	}
+	//Assert(ElementsValid(), "Degenerate Matrix inversion.");
 }
 
 }  // namespace ml

--- a/include/core-math/rng.h
+++ b/include/core-math/rng.h
@@ -140,8 +140,8 @@ namespace ml {
 		ulong MWC()  
 		{ return (((znew() << 16) + wnew()) & 0xfffffffful); }
 		ulong SHR3()
-		{ jsr ^= (jsr << 17); jsr ^= (jsr >> 13);
-		return (jsr = ((jsr ^= (jsr << 5)) & 0xfffffffful)); }
+		{ jsr ^= (jsr << 17); jsr ^= (jsr >> 13); jsr ^= (jsr << 5);
+		return (jsr = jsr & 0xfffffffful); }
 		ulong CONG() 
 		{ return (jcong = ((69069 * jcong + 1234567) & 0xfffffffful)); }
 		ulong rand_int32()         // [0,2^32-1]

--- a/include/core-math/sparseMatrix.cpp
+++ b/include/core-math/sparseMatrix.cpp
@@ -189,55 +189,55 @@ void SparseMatrix<D>::invertInPlace()
 			(*this)(j, i) = sum / (*this)(j, j);
 		}
 
-		//
-		// invert U
-		//
-		for (UINT i = 0; i < m_rows; i++)
-			for (UINT j = i; j < m_rows; j++)
+	//
+	// invert U
+	//
+	for (UINT i = 0; i < m_rows; i++)
+		for (UINT j = i; j < m_rows; j++)
+		{
+			if ( i == j )
 			{
-				if ( i == j )
-				{
-					continue;
-				}
-				D sum = 0;
-				for (UINT k = i; k < j; k++)
-				{
-					D val = (D)1.0;
-					if(i != k)
-					{
-						val = (*this)(i, k);
-					}
-					sum += (*this)(k, j) * val;
-				}
-				(*this)(i, j) = -sum;
+				continue;
 			}
+			D sum = 0;
+			for (UINT k = i; k < j; k++)
+			{
+				D val = (D)1.0;
+				if(i != k)
+				{
+					val = (*this)(i, k);
+				}
+				sum += (*this)(k, j) * val;
+			}
+			(*this)(i, j) = -sum;
+		}
 
-			//
-			// final inversion
-			//
-			for (UINT i = 0; i < m_rows; i++)
+	//
+	// final inversion
+	//
+	for (UINT i = 0; i < m_rows; i++)
+	{
+		for (UINT j = 0; j < m_rows; j++)
+		{
+			D sum = 0;
+			UINT larger = j;
+			if(i > j)
 			{
-				for (UINT j = 0; j < m_rows; j++)
-				{
-					D sum = 0;
-					UINT larger = j;
-					if(i > j)
-					{
-						larger = i;
-					}
-					for (UINT k = larger; k < m_rows; k++)
-					{
-						D val = (D)1.0;
-						if(j != k)
-						{
-							val = (*this)(j, k);
-						}
-						sum += val * (*this)(k, i);
-					}
-					(*this)(j, i) = sum;
-				}
+				larger = i;
 			}
-			//Assert(ElementsValid(), "Degenerate Matrix inversion.");
+			for (UINT k = larger; k < m_rows; k++)
+			{
+				D val = (D)1.0;
+				if(j != k)
+				{
+					val = (*this)(j, k);
+				}
+				sum += val * (*this)(k, i);
+			}
+			(*this)(j, i) = sum;
+		}
+	}
+	//Assert(ElementsValid(), "Degenerate Matrix inversion.");
 }
 
 }  // namespace ml

--- a/include/core-math/vec6.h
+++ b/include/core-math/vec6.h
@@ -294,7 +294,7 @@ public:
 	}
 
 	inline std::string toString(const std::string &separator) const {
-		return std::to_string(x) + separator + std::to_string(y) + separator + std::to_string(z) + separator + std::to_string(w) + separator + 
+		return std::to_string(x) + separator + std::to_string(y) + separator + std::to_string(z) + separator +
 			std::to_string(xx) + separator + std::to_string(yy) + separator + std::to_string(zz);
 	}
 

--- a/include/core-mesh/material.h
+++ b/include/core-mesh/material.h
@@ -103,8 +103,8 @@ public:
 	static void saveToMTL(const std::string& filename, const std::vector<Material>& _mats) {
 
 		std::vector<Material> mats = _mats;
-		auto glambda0 = [](const Materialf& m0, const Materialf& m1)	{ return m0.m_name < m1.m_name;	};
-		auto glambda1 = [](const Materialf& m0, const Materialf& m1)	{ return m0.m_name == m1.m_name; };
+		auto glambda0 = [](const Material& m0, const Material& m1)	{ return m0.m_name < m1.m_name;	};
+		auto glambda1 = [](const Material& m0, const Material& m1)	{ return m0.m_name == m1.m_name; };
 		std::sort(mats.begin(), mats.end(), glambda0);
 		auto last = std::unique(mats.begin(), mats.end(), glambda1);	//collapsing the same materials
 		mats.erase(last, mats.end()); 
@@ -118,7 +118,7 @@ public:
 			out << "Kd " << m.m_diffuse.x << " " << m.m_diffuse.y << " " << m.m_diffuse.z << "\n";
 			out << "Ks " << m.m_specular.x << " " << m.m_specular.y << " " << m.m_specular.z << "\n";
 			out << "Ns " << m.m_shiny << "\n";
-			out << "Ke " << m_emission << "\n";
+			out << "Ke " << m.m_emission << "\n";
 			out << "illum 2" << "\n";	//todo check the illum consistencies
 			if (m.m_TextureFilename_Ka != "")	out << "map_Ka " << m.m_TextureFilename_Ka << "\n";
 			if (m.m_TextureFilename_Kd != "")	out << "map_Kd " << m.m_TextureFilename_Kd << "\n";

--- a/include/core-util/binaryDataBuffer.h
+++ b/include/core-util/binaryDataBuffer.h
@@ -188,7 +188,7 @@ private:
 		if (!util::fileExists(m_filename))	m_fileSize = 0;	//in case there was no file before
 		else m_fileSize = util::getFileSize(m_filename);
 
-		std::ios_base::open_mode m = std::ios::binary;
+		std::ios_base::openmode m = std::ios::binary;
 		if (m_mode & Mode::read_flag) m |= std::ios::in;
 		if (m_mode & Mode::write_flag) m |= std::ios::out;
 

--- a/include/core-util/binaryDataStream.h
+++ b/include/core-util/binaryDataStream.h
@@ -361,7 +361,7 @@ namespace util
     {
         BinaryDataStreamFile in(filename, false);
         in >> o;
-        in.closeStream();
+        in.close();
     }
 
     template<class T, class U>
@@ -369,7 +369,7 @@ namespace util
     {
         BinaryDataStreamFile in(filename, false);
         in >> o0 >> o1;
-        in.closeStream();
+        in.close();
     }
 	//
 	// TODO: these cannot be forward declared without zlib, and should be moved into the mlib-zlib header.

--- a/include/core-util/binaryDataStream.h
+++ b/include/core-util/binaryDataStream.h
@@ -21,7 +21,7 @@ public:
 
 	//! only required for file streams: clear means write-only and delete file; otherwise it's read only
 	void open(const std::string& filename, bool clearStream) {
-		BinaryDataBuffer::Mode mode = BinaryDataBuffer::Mode::no_flag;
+		typename BinaryDataBuffer::Mode mode = BinaryDataBuffer::Mode::no_flag;
 		if (clearStream) {
 			mode |= BinaryDataBuffer::Mode::clear_flag | BinaryDataBuffer::Mode::write_flag;
 		}

--- a/include/core-util/textWriter.h
+++ b/include/core-util/textWriter.h
@@ -21,7 +21,7 @@ public:
         for (int y = 0; y < 16; y++)
             for (int x = 0; x < 16; x++)
             {
-                if (curCharacter >= ASCIICharacters.size()) break;
+                if (curCharacter >= (int)ASCIICharacters.size()) break;
                 ColorImageR8G8B8A8 &img = ASCIICharacters[curCharacter++];
                 img = bitmapFont.getSubregion(bbox2i(vec2i(x * 14, y * 16), vec2i((x + 1) * 14, (y + 1) * 16)));
             }
@@ -30,7 +30,7 @@ public:
     void writeNumber(ColorImageR8G8B8A8 &image, float value, int maxCharacters, const vec2i &coord)
     {
         std::string s = std::to_string(value);
-        if (s.length() > maxCharacters)
+        if ((int)s.length() > maxCharacters)
             s.resize(maxCharacters);
         writeText(image, s, coord);
     }
@@ -38,10 +38,10 @@ public:
     void writeText(ColorImageR8G8B8A8 &image, const std::string &text, const vec2i &coord)
     {
         int xOffset = 0;
-        for (int c = 0; c < text.size(); c++)
+        for (int c = 0; c < (int)text.size(); c++)
         {
             int cValue = (int)text[c];
-            if (cValue < 0 || cValue >= ASCIICharacters.size())
+            if (cValue < 0 || cValue >= (int)ASCIICharacters.size())
                 continue;
             const ColorImageR8G8B8A8 &character = ASCIICharacters[cValue];
             image.copyIntoImage(character, coord.x + xOffset, coord.y, false);	//copies irrespective whether dimensions match up (claps accordingly)

--- a/include/core-util/uniformAccelerator.h
+++ b/include/core-util/uniformAccelerator.h
@@ -20,7 +20,7 @@ namespace ml
             for (auto &v : points)
                 _bbox.include(v);
             init(_bbox, _cubeSize);
-            for (int i = 0; i < points.size(); i++)
+            for (int i = 0; i < (int)points.size(); i++)
                 addPoint(points[i], i);
         }
 

--- a/include/core-util/utility.h
+++ b/include/core-util/utility.h
@@ -461,7 +461,7 @@ namespace util
 	}
 
 	inline void checkedFSeek(UINT offset, FILE* file) {
-		int result = fseek(file, offset, SEEK_SET);
+		int result = fseek(file, offset, SEEK_SET); (void) result; // Silence unused warning
 		MLIB_ASSERT_STR(!ferror(file) && result == 0, "fseek failed");
 	}
 


### PR DESCRIPTION
Fixed some small compile issues in material.h
Silenced the signed v.s. unsigned comparison warnings in textWriter.h & uniformAccelerator.h
Silenced the gcc warnings about friend declaration on non-templated function in baseImage.h
Fixed gcc compile issues in distanceField3.h
Fixed an indentation in grid3.cpp
Fixed an undefined behavior in rng.h
Fixed a compile issue in vec6.h (there's no "w")
Fixed a compile issue in binaryDataStream.h (there is no "closeStream()" method)
Fixed a compile issue in binaryDataStream.h (need to add the "typename" identifier)
Fixed a compile issue in binaryDataBuffer.h (should be openmode instead of open_mode)
Silenced a unused variable warning in utility.h