### PR TITLE
Improve `include/*`: typo fixes

### DIFF
--- a/include/core-util/utility.h
+++ b/include/core-util/utility.h
@@ -164,7 +164,7 @@ namespace math
 	}
 
 	template<class T>
-	inline T nextLargeestPow2(T x) {
+	inline T nextLargestPow2(T x) {
 		x |= (x >> 1);
 		x |= (x >> 2);
 		x |= (x >> 4);
@@ -308,7 +308,7 @@ namespace math
 		return dis(gen);
 	}
 
-	//! flips a coin: 50% chance to retrun true; otherwise false
+	//! flips a coin: 50% chance to return true; otherwise false
 	inline bool randomCointoss() {
 		if (randomUniform(0.0f, 1.0f) > 0.5f) return false;	//there may be some bias
 		else return true;
@@ -428,7 +428,7 @@ namespace util
        
     inline void runSystemCommand(const std::string &s)
     {
-		//TODO fix it: this should in theroy call s = util::replace(s, "/", "\\");
+		//TODO fix it: this should in theory call s = util::replace(s, "/", "\\");
         system(s.c_str());
     }
 

--- a/include/mLibOpenMesh.h
+++ b/include/mLibOpenMesh.h
@@ -10,7 +10,7 @@
 //#define OM_STATIC_BUILD
 //#endif
 
-//This is pretty bad design choice to define it here because it will cause different behaviror if math.h was included before...
+//This is pretty bad design choice to define it here because it will cause different behaviour if math.h was included before...
 #ifndef _USE_MATH_DEFINES
 #define _USE_MATH_DEFINES
 #endif


### PR DESCRIPTION
Improves:
- [`include/mLibOpenMesh.h`](https://github.com/niessner/mLib/pull/16/commits/bc521e65ae5ca168cd073dcc43a401f7bcda3ae5)
- [`include/core-util/utility.h`](https://github.com/niessner/mLib/pull/16/commits/22ed61284150bc34122c94e9bb6e06f86a31b361)